### PR TITLE
Graph image URLs are absolute

### DIFF
--- a/media/js/base.js
+++ b/media/js/base.js
@@ -142,6 +142,12 @@ function build_url(original_url, new_params) {
     params = get_url_params(original_url);
     $.extend(params, new_params);
     var url = original_url.split('?')[0] + '?';
+
+    // The backend returns absolute URLs
+    if (url.charAt(0) == '/') {
+        url = url.substring(1, url.length);
+    }
+
     for (key in params) {
         if (params[key] != '' || params[key] == 0) {
         url += key + '=' + params[key] + ';';


### PR DESCRIPTION
Everything in collectd-web seems to work great under a subdirectory since the URLs it generates for assets are relative... all except the graph URLs.

These URLs are generated server side and muted in JS. I just added some JS to strip out the '/'.

Ideally the server would be generating relative URLs instead, but that seems like a much more complex change.
