### PR TITLE
Fix conntrack plugin entries

### DIFF
--- a/cgi-bin/collection.modified.cgi
+++ b/cgi-bin/collection.modified.cgi
@@ -1048,9 +1048,9 @@ sub load_graph_definitions {
         ],
         conntrack => [
             '-v', 'Entries',
-            'DEF:min={file}:entropy:MIN',
-            'DEF:avg={file}:entropy:AVERAGE',
-            'DEF:max={file}:entropy:MAX',
+            'DEF:min={file}:value:MIN',
+            'DEF:avg={file}:value:AVERAGE',
+            'DEF:max={file}:value:MAX',
             "AREA:max#$HalfBlue",
             "AREA:min#$Canvas",
             "LINE1:avg#$FullBlue:Count",


### PR DESCRIPTION
Entries definition for the conntrack plugin are wrong, at least on collectd 5.1.
