### PR TITLE
filecount and contextswitch plugin support

### DIFF
--- a/cgi-bin/collection.modified.cgi
+++ b/cgi-bin/collection.modified.cgi
@@ -3245,6 +3245,21 @@ sub load_graph_definitions {
             'GPRINT:avg:LAST:%9.3lf Last'
         ],
 # nm-4Sept13 filecount - END
+# nm-4Sept13 contextswitch
+        contextswitch => [
+            '-v',
+            'Context Switches /s',
+            'DEF:avg={file}:value:AVERAGE',
+            'DEF:min={file}:value:MIN',
+            'DEF:max={file}:value:MAX',
+            "AREA:avg#$HalfBlue",
+            "LINE1:avg#$FullBlue:Switches/s",
+            'GPRINT:min:MIN:%9.3lf Min,',
+            'GPRINT:avg:AVERAGE:%9.3lf Average,',
+            'GPRINT:max:MAX:%9.3lf Max,',
+            'GPRINT:avg:LAST:%9.3lf Last'
+        ],
+# nm-4Sept13 contextswitch - END
     };
     $GraphDefs->{'if_multicast'}        = $GraphDefs->{'ipt_packets'};
     $GraphDefs->{'if_tx_errors'}        = $GraphDefs->{'if_rx_errors'};


### PR DESCRIPTION
I've added support for the filecount plugin and for the contextswitch plugin

There's a previous version of the support in the history - was thrown away in favour of the simpler final solution.
There's also one random bugfix the the DNS support which called an undefined function.
