### PR TITLE
The ping plugin uses "value" dataset name, not "ping"

### DIFF
--- a/cgi-bin/collection.modified.cgi
+++ b/cgi-bin/collection.modified.cgi
@@ -2296,9 +2296,9 @@ sub load_graph_definitions {
         ],
 # jaf-18aug11 END
         ping => [
-            'DEF:ping_avg={file}:ping:AVERAGE',
-            'DEF:ping_min={file}:ping:MIN',
-            'DEF:ping_max={file}:ping:MAX',
+            'DEF:ping_avg={file}:value:AVERAGE',
+            'DEF:ping_min={file}:value:MIN',
+            'DEF:ping_max={file}:value:MAX',
             "AREA:ping_max#$HalfBlue",
             "AREA:ping_min#$Canvas",
             "LINE1:ping_avg#$FullBlue:Ping",


### PR DESCRIPTION
Using collectd 5.4.1, the RRD files are produced with DS name "value", not "ping". Looking at collectd's git lof of src/ping.c, I was not able to find out when this got changed.

Random googling suggests that this was reported back in 2012 via https://groups.google.com/forum/#!msg/collectd-web-users/S6bAC-L5FT0/9nuHhw6kvT0J .
