### PR TITLE
Add libcgi-pm-perl to list of dependencies

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ For Debian-based linux distribution
 
 Install the following dependencies
 
-	apt-get install librrds-perl libjson-perl libhtml-parser-perl
+	apt-get install librrds-perl libjson-perl libhtml-parser-perl libcgi-pm-perl
 
 Using the webserver
 ===================


### PR DESCRIPTION
Under debian stretch, CGI.pm is in it's own package.