### PR TITLE
Fix Graph Data Source and Update `.gitignore` in Collectd-Web

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 docs/_build/*
 .env
+**/node_modules

--- a/cgi-bin/collection.modified.cgi
+++ b/cgi-bin/collection.modified.cgi
@@ -3145,9 +3145,9 @@ sub load_graph_definitions {
         timeleft => [
             '-v',
             'Minutes',
-            'DEF:avg={file}:timeleft:AVERAGE',
-            'DEF:min={file}:timeleft:MIN',
-            'DEF:max={file}:timeleft:MAX',
+            'DEF:avg={file}:value:AVERAGE',
+            'DEF:min={file}:value:MIN',
+            'DEF:max={file}:value:MAX',
             "AREA:max#$HalfBlue",
             "AREA:min#$Canvas",
             "LINE1:avg#$FullBlue:Time left [min]",


### PR DESCRIPTION
### **Overview**
This PR corrects an issue with the data source used in timeleft graph definitions and improves `.gitignore` by adding `node_modules`.

### **Changes**
- **Graph Definition Fix:**
  - Changed the data source for `timeleft` graphs from `timeleft` to `value` to ensure correct readings.
  
- **Code Cleanup:**
  - Updated `.gitignore` to exclude `node_modules`, preventing unnecessary files from being tracked.

### **Justification**
- Fixes incorrect graph rendering due to the wrong data source.
- Prevents `node_modules` from being committed, keeping the repository clean.

### **Impact**
- Users will see accurate `timeleft` graph data.
- No breaking changes; this is a bug fix and minor cleanup.