### PR TITLE
Add systemd service support for collectd-web

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,22 +52,49 @@ datadir: "/etc/collectd/collectd-web/"
 
 ### Debian-based Installation
 
-If you are using a Debian-based distribution, install the necessary dependencies:
+To install **collectd-web**, you need to download the latest `.deb` package from the [GitHub Releases](https://github.com/httpdss/collectd-web/releases) page.
 
-```bash
-sudo apt update
-sudo apt install librrds-perl libjson-perl libhtml-parser-perl libcgi-pm-perl fonts-recommended python3-dotenv
-```
+### Steps:
+
+1. **Find the Latest Release**
+   Navigate to the [collectd-web Releases](https://github.com/httpdss/collectd-web/releases) page.
+
+2. **Download the `.deb` File**
+   You can manually download the latest `.deb` file from the release assets or use the following command to fetch it automatically:
+
+   ```bash
+   wget $(curl -s https://api.github.com/repos/httpdss/collectd-web/releases/latest | grep "browser_download_url.*\.deb" | cut -d '"' -f 4)
+   ```
+
+3. **Install the Package**
+   Once downloaded, install it using:
+
+   ```bash
+   sudo dpkg -i collectd-web*.deb
+   ```
+
+4. **Resolve Dependencies (if needed)**
+   If there are missing dependencies, run:
+
+   ```bash
+   sudo apt-get install -f
+   ```
 
 ## 🌐 Usage
+
+### Standalone Server
 
 To start the Collectd-web standalone server, simply run:
 
 ```bash
-python runserver.py
+sudo service collectd-web start
 ```
 
 Once running, open your web browser and navigate to the provided address (typically `http://localhost:8888`) to begin monitoring your systems.
+
+### Nginx Configuration
+
+Check the [Nginx configuration](debian/collectd-web.nginx.conf) for setting up Collectd-web with Nginx.
 
 ### Apache Configuration
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+collectd-web (0.11.1) bookworm; urgency=low
+
+  * Add systemd service file.
+
+ -- Kenneth Belitzky <kenny@belitzky.com>  Sun, 03 Feb 2025 19:43:00 -0300
+
 collectd-web (0.5.0+20250303) bookworm; urgency=low
 
   * Sync code with upstream.

--- a/debian/collectd-web.service
+++ b/debian/collectd-web.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Collectd Web UI
+After=network.target
+
+[Service]
+ExecStart=/usr/bin/python3 /usr/share/collectd-web/runserver.py
+WorkingDirectory=/usr/share/collectd-web
+Restart=always
+User=collectd
+Group=collectd
+Environment=PYTHONUNBUFFERED=1
+StandardOutput=journal
+StandardError=journal
+ExecStop=/bin/kill -SIGTERM $MAINPID
+
+[Install]
+WantedBy=multi-user.target

--- a/debian/collectd-web.service
+++ b/debian/collectd-web.service
@@ -6,8 +6,6 @@ After=network.target
 ExecStart=/usr/bin/python3 /usr/share/collectd-web/runserver.py
 WorkingDirectory=/usr/share/collectd-web
 Restart=always
-User=collectd
-Group=collectd
 Environment=PYTHONUNBUFFERED=1
 StandardOutput=journal
 StandardError=journal

--- a/debian/install
+++ b/debian/install
@@ -3,4 +3,5 @@ media usr/share/collectd-web
 mobile usr/share/collectd-web
 index.html usr/share/collectd-web
 runserver.py usr/share/collectd-web
+collectd-web.service etc/systemd/system
 debian/collectd-web.nginx.conf usr/share/collectd-web/examples/

--- a/debian/install
+++ b/debian/install
@@ -3,5 +3,5 @@ media usr/share/collectd-web
 mobile usr/share/collectd-web
 index.html usr/share/collectd-web
 runserver.py usr/share/collectd-web
-collectd-web.service etc/systemd/system
+collectd-web.service usr/lib/systemd/system
 debian/collectd-web.nginx.conf usr/share/collectd-web/examples/

--- a/debian/postinst
+++ b/debian/postinst
@@ -1,6 +1,11 @@
 #!/bin/sh
 set -e
 
+if [ "$1" = "configure" ]; then
+    systemctl daemon-reload
+    systemctl enable collectd-web
+fi
+
 echo "Please install fcgiwrap and nginx, then copy or link the conf file:"
 echo "  ln -s /usr/share/collectd-web/examples/collectd-web.nginx.conf /etc/nginx/conf.d/"
 echo "then reload nginx to enable collectd-web."

--- a/debian/prerm
+++ b/debian/prerm
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+if [ "$1" = "remove" ]; then
+    systemctl stop collectd-web || true
+    systemctl disable collectd-web || true
+    systemctl daemon-reload
+fi


### PR DESCRIPTION
Introduce a systemd service file for collectd-web to manage its execution and enable automatic startup. Update installation scripts to handle service configuration and removal.