### PR TITLE
In success case, CGI scripts should return 0, not 1.

### DIFF
--- a/cgi-bin/collection.modified.cgi
+++ b/cgi-bin/collection.modified.cgi
@@ -379,7 +379,7 @@ sub list_hosts_json {
         -Charset      => 'utf-8'
     );
     print STDOUT to_json( $host_ref, { pretty => 1, indent => 2 } );
-    return (1);
+    return (0);
 }    # list_hosts_json
 
 sub _string_to_color {
@@ -492,7 +492,7 @@ sub action_show_host_json
     );
     print STDOUT to_json ([sort (keys %$all_plugins)],
     { pretty => 1, indent => 2 }) . "\n";
-    return (1);
+    return (0);
 } # action_show_host_json
 
 
@@ -787,7 +787,7 @@ sub action_show_plugin_json {
                            year => [@plugin_list_year],
                            decade => [@plugin_list_decade]},
     { pretty => 1, indent => 2 }) . "\n";
-    return (1);
+    return (0);
 }    # action_show_plugin_json
 
 sub action_show_type {


### PR DESCRIPTION
### Issue

When running the included Python server for collectd-web, there are lots of errors like this in the log (i.e. on stdout);

127.0.0.1 - - [06/Dec/2025 22:02:29] CGI script exit code 1

These are not needed or wanted, since in all three cases the code was executed successfully.

### Description

Make the CGI script return 0 instead of 1, which is interpreted as an error.

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/httpdss/collectd-web/blob/main/README.md#contributing).

Yes - and noticed that the link is broken and should be https://github.com/httpdss/collectd-web/blob/master/.github/CONTRIBUTING.md instead.

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have updated the documentation accordingly.

### Screenshots (if applicable)
<!-- Add screenshots to illustrate the changes made in the pull request -->

### Additional Comments
<!-- Add any other context or comments about the pull request here -->
