### PR TITLE
[codex] add installation and deployment guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,7 @@ Found a bug? Please [open an issue](https://github.com/httpdss/collectd-web/issu
 ## 📊 Table of Contents
 
 - [🚀 Features](#-features)
-- [🛠 Installation](#-installation)
-  - [Prerequisites](#prerequisites)
-  - [Configuration](#configuration)
-  - [Debian-based Installation](#debian-based-installation)
-- [🌐 Usage](#-usage)
+- [🛠 Installation and Usage](#-installation-and-usage)
 - [🔗 Links](#-links)
 - [📄 License](#-license)
 - [💰 Funding](#-funding)
@@ -41,94 +37,19 @@ Found a bug? Please [open an issue](https://github.com/httpdss/collectd-web/issu
 
 ![Collectd-web UI](docs/ui.png)
 
-## 🛠 Installation
+## 🛠 Installation and Usage
 
-### Prerequisites
+For installation, deployment, and troubleshooting details, see [docs/installation.md](docs/installation.md).
 
-Before installing Collectd-web, please ensure:
+That guide covers:
 
-- **Directory Structure:**
-  Organize your files so that each host's data resides in its own sub-directory named after the host. For example:
+- Debian / Ubuntu package install
+- standalone server usage
+- Nginx reverse proxy setup
+- Apache CGI setup
+- common graph, permission, and service startup problems
 
-  ```sh
-  /etc/collectd/collectd-web/localhost/
-  ```
-
-- **Python 3.6+ Requirement:**
-  The standalone web server requires Python version 3.6 or higher.
-
-### Configuration
-
-After setting up your directories, create a configuration file to define your data directory. For example, create `/etc/collectd/collection.conf` with the following content:
-
-```sh
-datadir: "/etc/collectd/collectd-web/"
-```
-
-### Debian-based Installation
-
-To install **collectd-web**, you need to download the latest `.deb` package from the [GitHub Releases](https://github.com/httpdss/collectd-web/releases) page.
-
-### Steps
-
-1. **Find the Latest Release**
-   Navigate to the [collectd-web Releases](https://github.com/httpdss/collectd-web/releases) page.
-
-2. **Download the `.deb` File**
-   You can manually download the latest `.deb` file from the release assets or use the following command to fetch it automatically:
-
-   ```bash
-   wget $(curl -s https://api.github.com/repos/httpdss/collectd-web/releases/latest | grep "browser_download_url.*\.deb" | cut -d '"' -f 4)
-   ```
-
-3. **Install the Package**
-   Once downloaded, install it using:
-
-   ```bash
-   sudo dpkg -i collectd-web*.deb
-   ```
-
-4. **Resolve Dependencies (if needed)**
-   If there are missing dependencies, run:
-
-   ```bash
-   sudo apt-get install -f
-   ```
-
-5. **Start the Service**
-   Finally, start the service:
-
-   ```bash
-   sudo service collectd-web start
-   ```
-
-## 🌐 Usage
-
-### Standalone Server
-
-To start the Collectd-web standalone server, simply run:
-
-```bash
-sudo service collectd-web start
-```
-
-Once running, open your web browser and navigate to the provided address (typically `http://localhost:8888`) to begin monitoring your systems.
-
-### Nginx Configuration
-
-Check the [Nginx configuration](debian/collectd-web.nginx.conf) for setting up Collectd-web with Nginx.
-
-### Apache Configuration
-
-Add these lines to your apache vhost configuration:
-
-```apache
-    Alias /collectd-web/collectd-web /path/to/vhost/httdocs/collectd-web
-    <Directory /path/to/vhost/httdocs/collectd-web/cgi-bin>
-      Options +ExecCGI +FollowSymLinks
-      AddHandler cgi-script .cgi .pl
-    </Directory>
-```
+The standalone server default is `http://127.0.0.1:8888/`.
 
 ## 🔗 Links
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,161 @@
+# Installation, Deployment, and Troubleshooting
+
+This guide covers the most common collectd-web deployment paths:
+
+- Debian/Ubuntu package install
+- Standalone server usage
+- Nginx reverse proxy
+- Apache CGI setup
+- Common startup, graph, and permissions issues
+
+## Prerequisites
+
+collectd-web expects:
+
+- collectd to be generating RRD data
+- a host-specific data directory layout
+- Python 3 with `python3-dotenv` available for the standalone server
+
+The standalone server listens on `127.0.0.1:8888` by default. You can override that with the `HOST` and `PORT` environment variables or by passing arguments to `runserver.py`.
+
+## Debian / Ubuntu package install
+
+If you have a built `.deb` package, install it with:
+
+```bash
+sudo dpkg -i collectd-web_*.deb
+sudo apt-get -f install
+```
+
+The Debian package installs files under:
+
+- `/usr/share/collectd-web/`
+- `/usr/share/collectd-web/runserver.py`
+- `/usr/share/collectd-web/cgi-bin/`
+
+The packaged service runs the standalone server from `/usr/share/collectd-web/runserver.py`.
+
+To start it after installation:
+
+```bash
+sudo service collectd-web start
+```
+
+If you use systemd directly, the service file is configured to execute:
+
+```bash
+/usr/bin/python3 /usr/share/collectd-web/runserver.py
+```
+
+## Standalone server
+
+For local testing or a non-packaged install, run:
+
+```bash
+python3 runserver.py
+```
+
+You can also bind explicitly:
+
+```bash
+python3 runserver.py 127.0.0.1 8888
+```
+
+Or override via environment:
+
+```bash
+HOST=0.0.0.0 PORT=8888 python3 runserver.py
+```
+
+The default URL is:
+
+```text
+http://127.0.0.1:8888/
+```
+
+## Data directory layout
+
+collectd-web expects per-host data directories. A common layout is:
+
+```text
+/etc/collectd/collectd-web/
+└── localhost/
+```
+
+Your configuration should point `datadir` at the parent directory:
+
+```text
+datadir: "/etc/collectd/collectd-web/"
+```
+
+If your collectd RRD files live elsewhere, update `datadir` to match that path.
+
+## Nginx reverse proxy
+
+The package includes a sample Nginx config at `debian/collectd-web.nginx.conf`:
+
+```nginx
+server {
+    listen 80;
+    server_name localhost;
+
+    root /usr/share/collectd-web/;
+    autoindex off;
+
+    location ~ \.cgi$ {
+        fastcgi_pass unix:/var/run/fcgiwrap.socket;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        include fastcgi_params;
+    }
+}
+```
+
+Typical assumptions:
+
+- `fcgiwrap` is installed and running
+- the web root is `/usr/share/collectd-web/`
+- the CGI scripts under `cgi-bin/` are executable
+
+If graphs do not render, confirm that Nginx can reach the FastCGI socket and that the CGI script path resolves correctly.
+
+## Apache setup
+
+For Apache, enable CGI execution for the collectd-web directory and allow the CGI scripts to run:
+
+```apache
+Alias /collectd-web/ /path/to/collectd-web/
+
+<Directory /path/to/collectd-web/cgi-bin>
+  Options +ExecCGI +FollowSymLinks
+  AddHandler cgi-script .cgi .pl
+</Directory>
+```
+
+Adjust `/path/to/collectd-web/` to match where the files are installed on your system.
+
+## Troubleshooting
+
+### Missing graphs
+
+- Confirm the `datadir` points to the directory that contains your host RRD files.
+- Check that collectd is writing data for the selected host.
+- Verify the user running collectd-web can read the RRD files.
+
+### Permissions problems
+
+- Make sure the web server or standalone process can read the `datadir` tree.
+- Check the ownership and mode on the RRD directories.
+- If you are using a package install, confirm the service runs as the expected user.
+
+### Missing dependencies
+
+- For the Debian package, run `sudo apt-get -f install` after `dpkg -i`.
+- For standalone usage, install `python3-dotenv` and any Python modules required by your environment.
+- For CGI deployments, make sure `fcgiwrap`, Nginx, or Apache CGI support is installed and enabled.
+
+### Service startup issues
+
+- Inspect the service logs with `journalctl -u collectd-web`.
+- Confirm that `/usr/share/collectd-web/runserver.py` exists after package install.
+- Verify `HOST` and `PORT` are valid and not already in use.
+


### PR DESCRIPTION
## Summary
- Added `docs/installation.md`, a central guide for installing, deploying, configuring, and troubleshooting collectd-web.
- Consolidated the README installation and usage section into a link to the new guide, keeping the project landing page concise while retaining the key deployment information.

## Documentation coverage
- Debian/Ubuntu package installation and service startup
- Standalone server defaults and `HOST`/`PORT` overrides
- Expected collectd RRD data-directory layout and `datadir` configuration
- Nginx reverse-proxy and Apache CGI setup
- Troubleshooting missing graphs, permissions, dependencies, and startup failures

## Validation
- Manually reviewed the README link and installation guide structure.
- Documentation-only change; no runtime behavior changed.